### PR TITLE
Add editing workflow for saved recipes

### DIFF
--- a/app/Http/Controllers/SavedRecipeController.php
+++ b/app/Http/Controllers/SavedRecipeController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\SavedRecipe;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
 
 class SavedRecipeController extends Controller
 {
@@ -54,6 +55,48 @@ class SavedRecipeController extends Controller
     {
         $recipes = Auth::user()->savedRecipes()->latest()->get();
         return view('saved_recipes.index', compact('recipes'));
+    }
+
+    // Update an existing recipe
+    public function update(Request $request, $id)
+    {
+        $recipe = SavedRecipe::where('id', $id)
+            ->where('user_id', Auth::id())
+            ->firstOrFail();
+
+        $validator = Validator::make($request->all(), [
+            'title' => 'required|string|max:255|unique:saved_recipes,title,' . $recipe->id . ',id,user_id,' . Auth::id(),
+            'category' => 'required|string|max:255',
+            'custom_category' => 'nullable|string|max:255',
+            'summary' => 'nullable|string',
+        ], [
+            'category.required' => 'Please select a category for your recipe.',
+        ]);
+
+        $validator->after(function ($validator) use ($request) {
+            if ($request->input('category') === 'other' && trim($request->input('custom_category', '')) === '') {
+                $validator->errors()->add('custom_category', 'Please enter a custom category name.');
+            }
+        });
+
+        if ($validator->fails()) {
+            return redirect()
+                ->route('recipes.index')
+                ->withErrors($validator)
+                ->withInput($request->all() + ['editing_id' => $recipe->id]);
+        }
+
+        $category = $request->input('category');
+        if ($category === 'other') {
+            $category = trim($request->input('custom_category', ''));
+        }
+
+        $recipe->title = $request->input('title');
+        $recipe->category = $category;
+        $recipe->summary = $request->input('summary');
+        $recipe->save();
+
+        return redirect()->route('recipes.index')->with('success', 'Recipe updated!');
     }
 
     // Delete a saved recipe

--- a/resources/views/saved_recipes/index.blade.php
+++ b/resources/views/saved_recipes/index.blade.php
@@ -13,18 +13,32 @@
         .section-header { font-weight: bold; color: #007bff; margin: 14px 0 6px 0; display: flex; align-items: center; font-size: 1.1em; }
         .section-header .icon { margin-right: 7px; }
         ul, ol { margin-left: 22px; margin-bottom: 13px; }
-        .summary { background: #e3f5ff; border-radius: 6px; padding: 13px 14px; margin-top: 8px; color: #2c3e50; font-size: 1em;}
+        .summary { background: #e3f5ff; border-radius: 6px; padding: 13px 14px; margin-top: 8px; color: #2c3e50; font-size: 1em; }
         .delete-btn { background: #ff5e5e; color: #fff; border: none; padding: 8px 18px; border-radius: 4px; cursor: pointer; margin-top: 13px; font-size: 0.98em; transition: background .18s; }
         .delete-btn:hover { background: #e20000; }
+        .edit-btn { background: #38b6ff; color: #fff; border: none; padding: 8px 18px; border-radius: 4px; cursor: pointer; font-size: 0.98em; transition: background .18s; margin-right: 10px; }
+        .edit-btn:hover { background: #109cff; }
+        .action-row { display: flex; align-items: center; margin-top: 18px; gap: 12px; flex-wrap: wrap; }
+        .edit-form { margin-top: 18px; background: #f1f7ff; border-radius: 8px; padding: 16px; border: 1px solid #cfe8ff; }
+        .form-group { margin-bottom: 14px; }
+        .form-group label { display: block; font-weight: bold; color: #1f2937; margin-bottom: 6px; }
+        .form-group input[type="text"],
+        .form-group select,
+        .form-group textarea { width: 100%; padding: 8px 10px; border: 1px solid #cbd5e1; border-radius: 4px; font-size: 0.95em; box-sizing: border-box; }
+        .form-group textarea { min-height: 90px; resize: vertical; }
+        .save-changes-btn { background: #22c55e; color: #fff; border: none; padding: 9px 18px; border-radius: 4px; cursor: pointer; font-size: 0.98em; transition: background .18s; }
+        .save-changes-btn:hover { background: #16a34a; }
+        .cancel-edit { background: transparent; border: none; color: #64748b; margin-left: 12px; cursor: pointer; font-size: 0.95em; }
+        .field-error { color: #dc2626; font-size: 0.85em; margin-top: 4px; }
         .nav-buttons { text-align: center; margin-bottom: 20px; }
-        .home-btn { 
-            background: #38b6ff; 
-            color: #fff; 
-            border: none; 
-            padding: 10px 20px; 
-            border-radius: 4px; 
-            font-size: 1em; 
-            cursor: pointer; 
+        .home-btn {
+            background: #38b6ff;
+            color: #fff;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            font-size: 1em;
+            cursor: pointer;
             text-decoration: none;
             display: inline-block;
             transition: background .18s;
@@ -33,6 +47,8 @@
         @media (max-width: 600px) {
             .container { padding: 12px 3vw; }
             .recipe-card { padding: 14px 6vw; }
+            .action-row { flex-direction: column; align-items: flex-start; }
+            .cancel-edit { margin-left: 0; margin-top: 8px; }
         }
     </style>
 </head>
@@ -59,14 +75,39 @@
         @if($recipes->isEmpty())
             <p style="text-align:center; color:#888; font-size:1.1em;">No recipes saved yet. Go cook up something awesome!</p>
         @else
+            @php
+                $availableCategories = ['Breakfast', 'Lunch', 'Dinner', 'Dessert', 'Snack', 'Appetizer', 'Beverage'];
+                $editingId = old('editing_id');
+            @endphp
             @foreach($recipes as $recipe)
+                @php
+                    $isEditingThis = (string)$editingId === (string)$recipe->id;
+                    $categoryFromOld = $isEditingThis ? old('category') : null;
+                    $currentCategory = $categoryFromOld !== null ? $categoryFromOld : ($recipe->category ?? '');
+                    $isCustomCategory = false;
+                    $customCategoryValue = '';
+
+                    if ($categoryFromOld !== null) {
+                        if ($categoryFromOld === 'other') {
+                            $isCustomCategory = true;
+                            $customCategoryValue = old('custom_category', '');
+                        }
+                    } elseif ($recipe->category && !in_array($recipe->category, $availableCategories)) {
+                        $isCustomCategory = true;
+                        $currentCategory = 'other';
+                        $customCategoryValue = $recipe->category;
+                    }
+
+                    $titleValue = $isEditingThis ? old('title', $recipe->title) : $recipe->title;
+                    $notesValue = $isEditingThis ? old('summary', $recipe->summary) : $recipe->summary;
+                @endphp
                 <div class="recipe-card">
                     <div class="recipe-title">{{ $recipe->title }}</div>
                     <div class="category">
                         <span style="font-size:1.15em;">&#128205;</span> <!-- 📍 -->
                         {{ $recipe->category ?? 'Uncategorized' }}
                     </div>
-                    
+
                     <div class="section-header"><span class="icon">&#129367;</span> Ingredients:</div>
                     <ul>
                         @foreach(explode("\n", $recipe->ingredients) as $ingredient)
@@ -86,18 +127,113 @@
                     </ol>
 
                     @if($recipe->summary)
-                        <div class="section-header"><span class="icon">&#128161;</span> Summary:</div>
+                        <div class="section-header"><span class="icon">&#128161;</span> Personal Notes:</div>
                         <div class="summary">{{ $recipe->summary }}</div>
                     @endif
 
-                    <form action="{{ route('recipes.destroy', $recipe->id) }}" method="POST">
-                        @csrf
-                        @method('DELETE')
-                        <button type="submit" class="delete-btn">Delete Recipe</button>
-                    </form>
+                    <div class="action-row">
+                        <button type="button" class="edit-btn" data-target="edit-form-{{ $recipe->id }}">Edit</button>
+                        <form action="{{ route('recipes.destroy', $recipe->id) }}" method="POST" style="margin:0;">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="delete-btn">Delete Recipe</button>
+                        </form>
+                    </div>
+
+                    <div class="edit-form" id="edit-form-{{ $recipe->id }}" style="{{ $isEditingThis ? 'display:block;' : 'display:none;' }}">
+                        <form action="{{ route('recipes.update', $recipe->id) }}" method="POST">
+                            @csrf
+                            @method('PUT')
+                            <input type="hidden" name="editing_id" value="{{ $recipe->id }}">
+                            <div class="form-group">
+                                <label for="title_{{ $recipe->id }}">Title</label>
+                                <input type="text" id="title_{{ $recipe->id }}" name="title" value="{{ $titleValue }}">
+                                @if($isEditingThis && $errors->has('title'))
+                                    <div class="field-error">{{ $errors->first('title') }}</div>
+                                @endif
+                            </div>
+                            <div class="form-group">
+                                <label for="category_{{ $recipe->id }}">Category</label>
+                                <select id="category_{{ $recipe->id }}" name="category" class="category-select" data-recipe-id="{{ $recipe->id }}">
+                                    <option value="">Select a category</option>
+                                    @foreach($availableCategories as $categoryOption)
+                                        <option value="{{ $categoryOption }}" {{ $currentCategory === $categoryOption ? 'selected' : '' }}>{{ $categoryOption }}</option>
+                                    @endforeach
+                                    <option value="other" {{ $currentCategory === 'other' ? 'selected' : '' }}>Other</option>
+                                </select>
+                                @if($isEditingThis && $errors->has('category'))
+                                    <div class="field-error">{{ $errors->first('category') }}</div>
+                                @endif
+                            </div>
+                            <div class="form-group" id="custom_category_group_{{ $recipe->id }}" style="{{ ($isEditingThis && old('category') === 'other') || $isCustomCategory ? 'display:block;' : 'display:none;' }}">
+                                <label for="custom_category_{{ $recipe->id }}">Custom Category</label>
+                                <input type="text" id="custom_category_{{ $recipe->id }}" name="custom_category" value="{{ $isEditingThis ? old('custom_category', $customCategoryValue) : $customCategoryValue }}">
+                                @if($isEditingThis && $errors->has('custom_category'))
+                                    <div class="field-error">{{ $errors->first('custom_category') }}</div>
+                                @endif
+                            </div>
+                            <div class="form-group">
+                                <label for="summary_{{ $recipe->id }}">Personal Notes</label>
+                                <textarea id="summary_{{ $recipe->id }}" name="summary">{{ $notesValue }}</textarea>
+                                @if($isEditingThis && $errors->has('summary'))
+                                    <div class="field-error">{{ $errors->first('summary') }}</div>
+                                @endif
+                            </div>
+                            <button type="submit" class="save-changes-btn">Save Changes</button>
+                            <button type="button" class="cancel-edit" data-target="edit-form-{{ $recipe->id }}">Cancel</button>
+                        </form>
+                    </div>
                 </div>
             @endforeach
         @endif
     </div>
+    <script>
+        document.querySelectorAll('.edit-btn').forEach(function(button) {
+            button.addEventListener('click', function() {
+                var targetId = this.getAttribute('data-target');
+                var form = document.getElementById(targetId);
+                if (!form) return;
+                form.style.display = form.style.display === 'none' || form.style.display === '' ? 'block' : 'none';
+            });
+        });
+
+        document.querySelectorAll('.cancel-edit').forEach(function(button) {
+            button.addEventListener('click', function() {
+                var targetId = this.getAttribute('data-target');
+                var form = document.getElementById(targetId);
+                if (!form) return;
+                form.style.display = 'none';
+            });
+        });
+
+        function setupCategorySelect(select) {
+            var recipeId = select.getAttribute('data-recipe-id');
+            var customGroup = document.getElementById('custom_category_group_' + recipeId);
+            if (!customGroup) return;
+            var customInput = customGroup.querySelector('input');
+
+            var toggleCustom = function(value) {
+                if (value === 'other') {
+                    customGroup.style.display = 'block';
+                    if (customInput) {
+                        customInput.required = true;
+                    }
+                } else {
+                    customGroup.style.display = 'none';
+                    if (customInput) {
+                        customInput.required = false;
+                    }
+                }
+            };
+
+            toggleCustom(select.value);
+
+            select.addEventListener('change', function() {
+                toggleCustom(this.value);
+            });
+        }
+
+        document.querySelectorAll('.category-select').forEach(setupCategorySelect);
+    </script>
 </body>
-</html> 
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -154,6 +154,7 @@ Route::post('/recipe/ask', function (Request $request) {
 // =========== RECIPE ROUTES ============= //
 Route::post('/recipes/save', [SavedRecipeController::class, 'store'])->name('recipes.save')->middleware('auth');
 Route::get('/my-recipes', [SavedRecipeController::class, 'index'])->name('recipes.index')->middleware('auth');
+Route::put('/recipes/{id}', [SavedRecipeController::class, 'update'])->name('recipes.update')->middleware('auth');
 Route::delete('/recipes/{id}', [SavedRecipeController::class, 'destroy'])->name('recipes.destroy')->middleware('auth');
 
 // Import saved recipes from guest/local (auth only)


### PR DESCRIPTION
## Summary
- add inline edit controls to saved recipe cards so titles, categories, and personal notes can be updated
- validate and persist recipe edits with a dedicated update action that enforces per-user uniqueness and category rules

## Testing
- php artisan test *(fails: vendor/autoload.php missing because composer install requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68cefef33cd8832a92a1ba9b4856681a