### PR TITLE
Revamp recipe views with modern layout and responsive styling

### DIFF
--- a/resources/views/layouts/site.blade.php
+++ b/resources/views/layouts/site.blade.php
@@ -1,0 +1,660 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>@yield('title', config('app.name', 'PrepToEat'))</title>
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link href="https://fonts.bunny.net/css?family=figtree:400,500,600,700&display=swap" rel="stylesheet" />
+    <style>
+        :root {
+            --brand: #0f172a;
+            --surface: #ffffff;
+            --surface-alt: #f1f5f9;
+            --border: rgba(148, 163, 184, 0.35);
+            --accent: #38b6ff;
+            --accent-dark: #0f9ae0;
+            --danger: #ef4444;
+            --danger-dark: #dc2626;
+            --success: #22c55e;
+            --success-dark: #16a34a;
+            --text-primary: #0f172a;
+            --text-muted: #64748b;
+            --radius-large: 20px;
+            --shadow-lg: 0 22px 45px rgba(15, 23, 42, 0.08);
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: 'Figtree', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background: radial-gradient(circle at top left, rgba(56, 182, 255, 0.18), transparent 55%),
+                        radial-gradient(circle at top right, rgba(34, 197, 94, 0.12), transparent 50%),
+                        #f8fafc;
+            color: var(--text-primary);
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        a {
+            color: inherit;
+        }
+
+        .site-shell {
+            width: min(1100px, 92vw);
+            margin: 0 auto;
+        }
+
+        .site-header {
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.96), rgba(15, 23, 42, 0.88));
+            border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+            position: sticky;
+            top: 0;
+            z-index: 20;
+            backdrop-filter: blur(10px);
+        }
+
+        .site-header-inner {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            padding: 0.85rem 0;
+        }
+
+        .brand {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.65rem;
+            font-size: 1.35rem;
+            font-weight: 700;
+            color: #f8fafc;
+            text-decoration: none;
+            letter-spacing: 0.01em;
+        }
+
+        .brand-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 34px;
+            height: 34px;
+            border-radius: 12px;
+            background: rgba(56, 182, 255, 0.2);
+            color: #38b6ff;
+            font-weight: 600;
+            font-size: 1.05rem;
+        }
+
+        .nav-toggle {
+            display: none;
+            border: 1px solid rgba(148, 163, 184, 0.4);
+            background: transparent;
+            color: #e2e8f0;
+            border-radius: 10px;
+            padding: 0.45rem 0.55rem;
+            cursor: pointer;
+            transition: background 0.2s ease, color 0.2s ease;
+        }
+
+        .nav-toggle:hover {
+            background: rgba(148, 163, 184, 0.15);
+        }
+
+        .nav-menu {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .nav-menu a,
+        .nav-menu button,
+        .nav-menu span {
+            font-size: 0.95rem;
+            font-weight: 500;
+            color: #e2e8f0;
+            text-decoration: none;
+            padding: 0.5rem 0.85rem;
+            border-radius: 999px;
+            transition: background 0.25s ease, color 0.25s ease;
+            border: none;
+            background: transparent;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+        }
+
+        .nav-menu a:hover,
+        .nav-menu button:hover {
+            background: rgba(148, 163, 184, 0.22);
+            color: #ffffff;
+        }
+
+        .nav-menu .nav-cta {
+            background: linear-gradient(135deg, var(--accent), #60a5fa);
+            color: #0f172a;
+            box-shadow: 0 10px 25px rgba(96, 165, 250, 0.35);
+        }
+
+        .nav-menu .nav-cta:hover {
+            background: linear-gradient(135deg, var(--accent-dark), #3b82f6);
+            color: #f8fafc;
+        }
+
+        .nav-divider {
+            width: 1px;
+            height: 22px;
+            background: rgba(148, 163, 184, 0.35);
+            margin: 0 0.5rem;
+        }
+
+        .site-main {
+            flex: 1 0 auto;
+            padding: 2.5rem 0 4rem;
+        }
+
+        .content-shell {
+            width: min(1100px, 92vw);
+            margin: 0 auto;
+        }
+
+        .page-header {
+            text-align: center;
+            margin-bottom: 2.5rem;
+        }
+
+        .page-title {
+            font-size: clamp(1.8rem, 4vw, 2.4rem);
+            font-weight: 700;
+            margin-bottom: 0.8rem;
+            color: #0f172a;
+        }
+
+        .page-subtitle {
+            margin: 0 auto;
+            max-width: 620px;
+            color: var(--text-muted);
+            font-size: 1rem;
+        }
+
+        .card {
+            background: var(--surface);
+            border-radius: var(--radius-large);
+            box-shadow: var(--shadow-lg);
+            padding: clamp(1.5rem, 3vw, 2rem);
+            border: 1px solid rgba(148, 163, 184, 0.12);
+        }
+
+        .card + .card {
+            margin-top: 1.5rem;
+        }
+
+        .two-column {
+            display: grid;
+            gap: 2rem;
+        }
+
+        @media (min-width: 980px) {
+            .two-column {
+                grid-template-columns: 0.95fr 1.05fr;
+                align-items: start;
+            }
+        }
+
+        .form-group {
+            margin-bottom: 1rem;
+        }
+
+        .form-group label {
+            display: block;
+            font-weight: 600;
+            margin-bottom: 0.4rem;
+            color: #0f172a;
+        }
+
+        .input-control,
+        textarea,
+        select {
+            width: 100%;
+            border-radius: 12px;
+            border: 1px solid rgba(148, 163, 184, 0.45);
+            padding: 0.75rem 1rem;
+            font-size: 1rem;
+            font-family: inherit;
+            transition: border 0.2s ease, box-shadow 0.2s ease;
+            background: #ffffff;
+        }
+
+        textarea {
+            min-height: 140px;
+            resize: vertical;
+        }
+
+        .input-control:focus,
+        textarea:focus,
+        select:focus {
+            outline: none;
+            border-color: var(--accent);
+            box-shadow: 0 0 0 4px rgba(56, 182, 255, 0.18);
+        }
+
+        .btn {
+            border-radius: 12px;
+            border: none;
+            padding: 0.65rem 1.35rem;
+            font-size: 0.95rem;
+            font-weight: 600;
+            letter-spacing: 0.01em;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.4rem;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+        }
+
+        .btn:focus-visible {
+            outline: 2px solid var(--accent);
+            outline-offset: 3px;
+        }
+
+        .btn-primary {
+            background: linear-gradient(135deg, var(--accent), #60a5fa);
+            color: #0f172a;
+            box-shadow: 0 15px 30px rgba(56, 182, 255, 0.3);
+        }
+
+        .btn-primary:hover {
+            background: linear-gradient(135deg, var(--accent-dark), #3b82f6);
+            transform: translateY(-1px);
+        }
+
+        .btn-secondary {
+            background: rgba(15, 23, 42, 0.08);
+            color: var(--text-primary);
+        }
+
+        .btn-secondary:hover {
+            background: rgba(15, 23, 42, 0.12);
+        }
+
+        .btn-danger {
+            background: linear-gradient(135deg, var(--danger), #f87171);
+            color: #fff;
+            box-shadow: 0 14px 28px rgba(239, 68, 68, 0.3);
+        }
+
+        .btn-danger:hover {
+            background: linear-gradient(135deg, var(--danger-dark), #ef4444);
+        }
+
+        .btn-success {
+            background: linear-gradient(135deg, var(--success), #4ade80);
+            color: #0f172a;
+            box-shadow: 0 14px 28px rgba(34, 197, 94, 0.25);
+        }
+
+        .btn-success:hover {
+            background: linear-gradient(135deg, var(--success-dark), #22c55e);
+        }
+
+        .btn-light {
+            background: rgba(255, 255, 255, 0.1);
+            color: #e2e8f0;
+            border: 1px solid rgba(226, 232, 240, 0.35);
+        }
+
+        .btn-light:hover {
+            background: rgba(255, 255, 255, 0.22);
+        }
+
+        .btn-small {
+            padding: 0.45rem 1.05rem;
+            font-size: 0.85rem;
+        }
+
+        .alert {
+            border-radius: 16px;
+            padding: 0.9rem 1.1rem;
+            margin-bottom: 1.25rem;
+            font-size: 0.95rem;
+            font-weight: 500;
+        }
+
+        .alert-success {
+            background: rgba(22, 163, 74, 0.12);
+            color: #166534;
+            border: 1px solid rgba(22, 163, 74, 0.2);
+        }
+
+        .alert-error {
+            background: rgba(220, 38, 38, 0.12);
+            color: #b91c1c;
+            border: 1px solid rgba(220, 38, 38, 0.2);
+        }
+
+        .recipe-grid {
+            display: grid;
+            gap: 1.75rem;
+        }
+
+        @media (min-width: 700px) {
+            .recipe-grid {
+                grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            }
+        }
+
+        .recipe-card {
+            position: relative;
+            display: flex;
+            flex-direction: column;
+            gap: 1.25rem;
+            height: 100%;
+        }
+
+        .recipe-card header {
+            display: flex;
+            flex-direction: column;
+            gap: 0.4rem;
+        }
+
+        .recipe-title {
+            font-size: 1.25rem;
+            font-weight: 700;
+            margin: 0;
+        }
+
+        .recipe-meta {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.9rem;
+            color: var(--text-muted);
+        }
+
+        .recipe-tag {
+            background: rgba(56, 182, 255, 0.12);
+            color: var(--accent-dark);
+            padding: 0.25rem 0.75rem;
+            border-radius: 999px;
+            font-weight: 600;
+            font-size: 0.85rem;
+            letter-spacing: 0.01em;
+        }
+
+        .section-title {
+            display: flex;
+            align-items: center;
+            gap: 0.6rem;
+            font-size: 1rem;
+            font-weight: 600;
+            margin-bottom: 0.35rem;
+            color: #0f172a;
+        }
+
+        .icon-circle {
+            width: 34px;
+            height: 34px;
+            border-radius: 12px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            background: rgba(56, 182, 255, 0.18);
+            color: var(--accent);
+        }
+
+        .icon-circle svg {
+            width: 18px;
+            height: 18px;
+        }
+
+        .recipe-section ul,
+        .recipe-section ol {
+            margin: 0 0 1rem 1.2rem;
+            color: #1f2937;
+        }
+
+        .note-box {
+            background: rgba(56, 182, 255, 0.08);
+            border: 1px solid rgba(56, 182, 255, 0.2);
+            border-radius: 14px;
+            padding: 0.85rem 1rem;
+            color: #0f172a;
+        }
+
+        .card-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+        }
+
+        .edit-panel {
+            background: rgba(15, 23, 42, 0.03);
+            border: 1px solid rgba(148, 163, 184, 0.35);
+            border-radius: 16px;
+            padding: 1.1rem;
+            margin-top: 1rem;
+            display: none;
+        }
+
+        .field-error {
+            color: #dc2626;
+            font-size: 0.85rem;
+            margin-top: 0.35rem;
+        }
+
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            background: rgba(56, 182, 255, 0.12);
+            color: var(--accent-dark);
+            font-weight: 600;
+            border-radius: 999px;
+            padding: 0.35rem 0.75rem;
+            font-size: 0.85rem;
+        }
+
+        .summary-grid {
+            display: grid;
+            gap: 1.5rem;
+        }
+
+        @media (min-width: 880px) {
+            .summary-grid {
+                grid-template-columns: 1fr 1fr;
+            }
+        }
+
+        .stat-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.35rem 0.85rem;
+            background: rgba(15, 23, 42, 0.06);
+            border-radius: 999px;
+            font-weight: 600;
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .notice-banner {
+            display: none;
+            border-radius: 16px;
+            padding: 0.95rem 1.1rem;
+            background: rgba(34, 197, 94, 0.15);
+            border: 1px solid rgba(34, 197, 94, 0.22);
+            color: #166534;
+            font-weight: 500;
+            margin-bottom: 1.25rem;
+        }
+
+        .notice-banner button {
+            margin-left: 0.65rem;
+        }
+
+        .loading-indicator {
+            display: none;
+            align-items: center;
+            gap: 0.75rem;
+            margin-top: 1rem;
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .loading-indicator.is-visible {
+            display: inline-flex;
+        }
+
+        .spinner {
+            width: 30px;
+            height: 30px;
+            border-radius: 50%;
+            border: 3px solid rgba(148, 163, 184, 0.35);
+            border-top-color: var(--accent);
+            animation: spin 0.9s linear infinite;
+        }
+
+        @keyframes spin {
+            from {
+                transform: rotate(0deg);
+            }
+            to {
+                transform: rotate(360deg);
+            }
+        }
+
+        .empty-state {
+            text-align: center;
+            color: var(--text-muted);
+            display: grid;
+            gap: 0.85rem;
+        }
+
+        .empty-state svg {
+            width: 52px;
+            height: 52px;
+            margin: 0 auto;
+            color: rgba(56, 182, 255, 0.45);
+        }
+
+        .muted-link {
+            color: var(--text-muted);
+            text-decoration: none;
+        }
+
+        .muted-link:hover {
+            color: var(--accent-dark);
+        }
+
+        footer {
+            background: transparent;
+            padding: 2rem 0 3rem;
+            text-align: center;
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        @media (max-width: 768px) {
+            .nav-toggle {
+                display: inline-flex;
+            }
+
+            .nav-menu {
+                position: absolute;
+                top: calc(100% + 0.5rem);
+                left: 50%;
+                transform: translateX(-50%);
+                width: min(92vw, 420px);
+                background: rgba(15, 23, 42, 0.97);
+                border: 1px solid rgba(148, 163, 184, 0.25);
+                border-radius: 18px;
+                box-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
+                padding: 0.85rem;
+                display: none;
+                flex-direction: column;
+                align-items: stretch;
+                gap: 0.25rem;
+            }
+
+            .nav-menu a,
+            .nav-menu button,
+            .nav-menu span {
+                width: 100%;
+                justify-content: flex-start;
+                border-radius: 12px;
+            }
+
+            .nav-menu.is-open {
+                display: flex;
+            }
+
+            .site-header-inner {
+                position: relative;
+            }
+        }
+    </style>
+    @stack('styles')
+</head>
+<body>
+<header class="site-header">
+    <div class="site-shell site-header-inner">
+        <a href="{{ url('/') }}" class="brand">
+            <span class="brand-badge">🍳</span>
+            <span>PrepToEat</span>
+        </a>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" data-toggle-nav>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor" width="22" height="22">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+        </button>
+        <nav class="nav-menu" data-nav-menu>
+            <a href="{{ url('/') }}">Home</a>
+            @auth
+                <a href="{{ route('recipes.index') }}">My Recipes</a>
+                <a href="{{ route('dashboard') }}">Dashboard</a>
+                <span>Hi, {{ \Illuminate\Support\Str::limit(Auth::user()->name, 18) }}</span>
+                <div class="nav-divider" aria-hidden="true"></div>
+                <form action="{{ route('logout') }}" method="POST" style="margin: 0;">
+                    @csrf
+                    <button type="submit" class="btn btn-light btn-small">Logout</button>
+                </form>
+            @else
+                <a href="{{ route('recipes.local') }}">My Local Recipes</a>
+                <a href="{{ route('login') }}">Login</a>
+                <a href="{{ route('register') }}" class="nav-cta">Create Account</a>
+            @endauth
+        </nav>
+    </div>
+</header>
+<main class="site-main">
+    @yield('content')
+</main>
+<footer>
+    &copy; {{ now()->year }} PrepToEat. Crafted for easier home cooking.
+</footer>
+<script>
+    (function() {
+        const toggle = document.querySelector('[data-toggle-nav]');
+        const menu = document.querySelector('[data-nav-menu]');
+        if (!toggle || !menu) return;
+        toggle.addEventListener('click', function() {
+            menu.classList.toggle('is-open');
+        });
+        document.addEventListener('click', function(evt) {
+            if (!menu.classList.contains('is-open')) return;
+            const target = evt.target;
+            if (!menu.contains(target) && target !== toggle) {
+                menu.classList.remove('is-open');
+            }
+        });
+    })();
+</script>
+@stack('scripts')
+</body>
+</html>

--- a/resources/views/saved_recipes/index.blade.php
+++ b/resources/views/saved_recipes/index.blade.php
@@ -1,84 +1,41 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>My Saved Recipes | PrepToEat</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <style>
-        body { background: #f8fafc; font-family: Arial, sans-serif; margin: 0; }
-        .container { max-width: 750px; margin: 40px auto; background: #fff; border-radius: 14px; box-shadow: 0 4px 20px #e3f5ff; padding: 32px 24px 40px 24px; }
-        h1 { color: #38b6ff; margin-bottom: 30px; font-size: 2.2em; text-align: center; letter-spacing: 1px; }
-        .recipe-card { margin-bottom: 28px; border: 1px solid #e3f5ff; border-radius: 9px; padding: 26px 18px; background: #fafdff; }
-        .recipe-title { font-size: 1.45em; font-weight: bold; color: #2c3e50; margin-bottom: 3px; }
-        .category { color: #38b6ff; font-size: 1em; margin-bottom: 11px; }
-        .section-header { font-weight: bold; color: #007bff; margin: 14px 0 6px 0; display: flex; align-items: center; font-size: 1.1em; }
-        .section-header .icon { margin-right: 7px; }
-        ul, ol { margin-left: 22px; margin-bottom: 13px; }
-        .summary { background: #e3f5ff; border-radius: 6px; padding: 13px 14px; margin-top: 8px; color: #2c3e50; font-size: 1em; }
-        .delete-btn { background: #ff5e5e; color: #fff; border: none; padding: 8px 18px; border-radius: 4px; cursor: pointer; margin-top: 13px; font-size: 0.98em; transition: background .18s; }
-        .delete-btn:hover { background: #e20000; }
-        .edit-btn { background: #38b6ff; color: #fff; border: none; padding: 8px 18px; border-radius: 4px; cursor: pointer; font-size: 0.98em; transition: background .18s; margin-right: 10px; }
-        .edit-btn:hover { background: #109cff; }
-        .action-row { display: flex; align-items: center; margin-top: 18px; gap: 12px; flex-wrap: wrap; }
-        .edit-form { margin-top: 18px; background: #f1f7ff; border-radius: 8px; padding: 16px; border: 1px solid #cfe8ff; }
-        .form-group { margin-bottom: 14px; }
-        .form-group label { display: block; font-weight: bold; color: #1f2937; margin-bottom: 6px; }
-        .form-group input[type="text"],
-        .form-group select,
-        .form-group textarea { width: 100%; padding: 8px 10px; border: 1px solid #cbd5e1; border-radius: 4px; font-size: 0.95em; box-sizing: border-box; }
-        .form-group textarea { min-height: 90px; resize: vertical; }
-        .save-changes-btn { background: #22c55e; color: #fff; border: none; padding: 9px 18px; border-radius: 4px; cursor: pointer; font-size: 0.98em; transition: background .18s; }
-        .save-changes-btn:hover { background: #16a34a; }
-        .cancel-edit { background: transparent; border: none; color: #64748b; margin-left: 12px; cursor: pointer; font-size: 0.95em; }
-        .field-error { color: #dc2626; font-size: 0.85em; margin-top: 4px; }
-        .nav-buttons { text-align: center; margin-bottom: 20px; }
-        .home-btn {
-            background: #38b6ff;
-            color: #fff;
-            border: none;
-            padding: 10px 20px;
-            border-radius: 4px;
-            font-size: 1em;
-            cursor: pointer;
-            text-decoration: none;
-            display: inline-block;
-            transition: background .18s;
-        }
-        .home-btn:hover { background: #109cff; }
-        @media (max-width: 600px) {
-            .container { padding: 12px 3vw; }
-            .recipe-card { padding: 14px 6vw; }
-            .action-row { flex-direction: column; align-items: flex-start; }
-            .cancel-edit { margin-left: 0; margin-top: 8px; }
-        }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <div class="nav-buttons">
-            <a href="{{ url('/') }}" class="home-btn">Home</a>
+@extends('layouts.site')
+
+@section('title', 'My Saved Recipes | PrepToEat')
+
+@section('content')
+<div class="content-shell">
+    <div class="page-header">
+        <h1 class="page-title">My Saved Recipes</h1>
+        <p class="page-subtitle">Your personalized cookbook lives here. Edit, organize, and revisit your favourite dishes anytime.</p>
+    </div>
+
+    <div class="card" style="display:inline-block; margin-bottom:2rem;">
+        <a class="muted-link" href="{{ url('/') }}">&larr; Back to recipe creator</a>
+    </div>
+
+    @if(session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+
+    @if(session('error'))
+        <div class="alert alert-error">{{ session('error') }}</div>
+    @endif
+
+    @if($recipes->isEmpty())
+        <div class="card">
+            <div class="empty-state">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h10.5" />
+                </svg>
+                <div>No recipes saved yet. Generate one on the homepage and press <strong>Save Recipe</strong> to build your collection.</div>
+            </div>
         </div>
-        <h1>My Saved Recipes</h1>
-
-        {{-- Success/Error Messages --}}
-        @if(session('success'))
-            <div style="margin-bottom: 22px; padding:10px 18px; background: #e6ffe7; border-left: 5px solid #28b76b; border-radius: 5px; color:#25754a;">
-                {{ session('success') }}
-            </div>
-        @endif
-        @if(session('error'))
-            <div style="margin-bottom: 22px; padding:10px 18px; background: #ffe6e6; border-left: 5px solid #ff5e5e; border-radius: 5px; color:#952828;">
-                {{ session('error') }}
-            </div>
-        @endif
-
-        {{-- Recipe List --}}
-        @if($recipes->isEmpty())
-            <p style="text-align:center; color:#888; font-size:1.1em;">No recipes saved yet. Go cook up something awesome!</p>
-        @else
-            @php
-                $availableCategories = ['Breakfast', 'Lunch', 'Dinner', 'Dessert', 'Snack', 'Appetizer', 'Beverage'];
-                $editingId = old('editing_id');
-            @endphp
+    @else
+        @php
+            $availableCategories = ['Breakfast', 'Lunch', 'Dinner', 'Dessert', 'Snack', 'Appetizer', 'Beverage'];
+            $editingId = old('editing_id');
+        @endphp
+        <div class="recipe-grid">
             @foreach($recipes as $recipe)
                 @php
                     $isEditingThis = (string)$editingId === (string)$recipe->id;
@@ -100,61 +57,104 @@
 
                     $titleValue = $isEditingThis ? old('title', $recipe->title) : $recipe->title;
                     $notesValue = $isEditingThis ? old('summary', $recipe->summary) : $recipe->summary;
+
+                    $ingredientLines = array_values(array_filter(array_map('trim', preg_split('/\r?\n/', (string) ($recipe->ingredients ?? '')))));
+                    $instructionSteps = array_values(array_filter(array_map('trim', preg_split('/\r?\n/', (string) ($recipe->instructions ?? '')))));
+                    $summaryText = trim((string) ($recipe->summary ?? ''));
                 @endphp
-                <div class="recipe-card">
-                    <div class="recipe-title">{{ $recipe->title }}</div>
-                    <div class="category">
-                        <span style="font-size:1.15em;">&#128205;</span> <!-- 📍 -->
-                        {{ $recipe->category ?? 'Uncategorized' }}
-                    </div>
-
-                    <div class="section-header"><span class="icon">&#129367;</span> Ingredients:</div>
-                    <ul>
-                        @foreach(explode("\n", $recipe->ingredients) as $ingredient)
-                            @if(trim($ingredient) !== '')
-                                <li>{{ $ingredient }}</li>
+                <article class="card recipe-card">
+                    <header>
+                        <h2 class="recipe-title">{{ $recipe->title }}</h2>
+                        <div class="recipe-meta">
+                            <span class="recipe-tag">{{ $recipe->category ?? 'Uncategorized' }}</span>
+                            @if($recipe->created_at)
+                                <span>&bull;</span>
+                                <span>Saved {{ $recipe->created_at->format('M j, Y') }}</span>
                             @endif
-                        @endforeach
-                    </ul>
+                        </div>
+                    </header>
 
-                    <div class="section-header"><span class="icon">&#128221;</span> Instructions:</div>
-                    <ol>
-                        @foreach(explode("\n", $recipe->instructions) as $step)
-                            @if(trim($step) !== '')
+                    <section class="recipe-section">
+                        <div class="section-title">
+                            <span class="icon-circle">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 4.5h-3a2.25 2.25 0 00-2.25 2.25v3m5.25-5.25h9m0 0h3a2.25 2.25 0 012.25 2.25v3m-5.25-5.25v15m0 0h-9m9 0h3a2.25 2.25 0 002.25-2.25v-3m-14.25 5.25h-3A2.25 2.25 0 012.25 18v-3m0-6v9" />
+                                </svg>
+                            </span>
+                            Ingredients
+                        </div>
+                        <ul>
+                            @foreach($ingredientLines as $item)
+                                <li>{{ $item }}</li>
+                            @endforeach
+                        </ul>
+                    </section>
+
+                    <section class="recipe-section">
+                        <div class="section-title">
+                            <span class="icon-circle">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L6.832 19.82a4.5 4.5 0 01-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 011.13-1.897L16.862 4.487zm0 0L19.5 7.125" />
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M18 13.5V21" />
+                                </svg>
+                            </span>
+                            Instructions
+                        </div>
+                        <ol>
+                            @foreach($instructionSteps as $step)
                                 <li>{{ $step }}</li>
-                            @endif
-                        @endforeach
-                    </ol>
+                            @endforeach
+                        </ol>
+                    </section>
 
-                    @if($recipe->summary)
-                        <div class="section-header"><span class="icon">&#128161;</span> Personal Notes:</div>
-                        <div class="summary">{{ $recipe->summary }}</div>
+                    @if($summaryText !== '')
+                        <section class="recipe-section">
+                            <div class="section-title">
+                                <span class="icon-circle">
+                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 9.75L9 12l2.25 2.25m3-4.5L12 12l2.25 2.25M3.75 6h16.5M3.75 9.75h16.5M3.75 13.5h16.5M3.75 17.25h16.5" />
+                                    </svg>
+                                </span>
+                                Personal Notes
+                            </div>
+                            <div class="note-box">{{ $summaryText }}</div>
+                        </section>
                     @endif
 
-                    <div class="action-row">
-                        <button type="button" class="edit-btn" data-target="edit-form-{{ $recipe->id }}">Edit</button>
+                    <div class="card-actions">
+                        <button type="button" class="btn btn-secondary btn-small" data-edit-toggle="edit-form-{{ $recipe->id }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="18" height="18">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.688-1.688a1.875 1.875 0 112.652 2.652L6.832 19.82a4.5 4.5 0 01-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 011.13-1.897L16.862 4.487zm0 0L19.5 7.125" />
+                            </svg>
+                            Edit
+                        </button>
                         <form action="{{ route('recipes.destroy', $recipe->id) }}" method="POST" style="margin:0;">
                             @csrf
                             @method('DELETE')
-                            <button type="submit" class="delete-btn">Delete Recipe</button>
+                            <button type="submit" class="btn btn-danger btn-small" onclick="return confirm('Delete this recipe?');">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="18" height="18">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                                Delete
+                            </button>
                         </form>
                     </div>
 
-                    <div class="edit-form" id="edit-form-{{ $recipe->id }}" style="{{ $isEditingThis ? 'display:block;' : 'display:none;' }}">
+                    <div class="edit-panel" id="edit-form-{{ $recipe->id }}" style="{{ $isEditingThis ? 'display:block;' : '' }}">
                         <form action="{{ route('recipes.update', $recipe->id) }}" method="POST">
                             @csrf
                             @method('PUT')
                             <input type="hidden" name="editing_id" value="{{ $recipe->id }}">
                             <div class="form-group">
                                 <label for="title_{{ $recipe->id }}">Title</label>
-                                <input type="text" id="title_{{ $recipe->id }}" name="title" value="{{ $titleValue }}">
+                                <input type="text" id="title_{{ $recipe->id }}" name="title" class="input-control" value="{{ $titleValue }}">
                                 @if($isEditingThis && $errors->has('title'))
                                     <div class="field-error">{{ $errors->first('title') }}</div>
                                 @endif
                             </div>
                             <div class="form-group">
                                 <label for="category_{{ $recipe->id }}">Category</label>
-                                <select id="category_{{ $recipe->id }}" name="category" class="category-select" data-recipe-id="{{ $recipe->id }}">
+                                <select id="category_{{ $recipe->id }}" name="category" class="category-select">
                                     <option value="">Select a category</option>
                                     @foreach($availableCategories as $categoryOption)
                                         <option value="{{ $categoryOption }}" {{ $currentCategory === $categoryOption ? 'selected' : '' }}>{{ $categoryOption }}</option>
@@ -167,7 +167,7 @@
                             </div>
                             <div class="form-group" id="custom_category_group_{{ $recipe->id }}" style="{{ ($isEditingThis && old('category') === 'other') || $isCustomCategory ? 'display:block;' : 'display:none;' }}">
                                 <label for="custom_category_{{ $recipe->id }}">Custom Category</label>
-                                <input type="text" id="custom_category_{{ $recipe->id }}" name="custom_category" value="{{ $isEditingThis ? old('custom_category', $customCategoryValue) : $customCategoryValue }}">
+                                <input type="text" id="custom_category_{{ $recipe->id }}" name="custom_category" class="input-control" value="{{ $isEditingThis ? old('custom_category', $customCategoryValue) : $customCategoryValue }}">
                                 @if($isEditingThis && $errors->has('custom_category'))
                                     <div class="field-error">{{ $errors->first('custom_category') }}</div>
                                 @endif
@@ -179,40 +179,48 @@
                                     <div class="field-error">{{ $errors->first('summary') }}</div>
                                 @endif
                             </div>
-                            <button type="submit" class="save-changes-btn">Save Changes</button>
-                            <button type="button" class="cancel-edit" data-target="edit-form-{{ $recipe->id }}">Cancel</button>
+                            <div class="card-actions">
+                                <button type="submit" class="btn btn-success btn-small">Save Changes</button>
+                                <button type="button" class="btn btn-secondary btn-small" data-close-panel="edit-form-{{ $recipe->id }}">Cancel</button>
+                            </div>
                         </form>
                     </div>
-                </div>
+                </article>
             @endforeach
-        @endif
-    </div>
-    <script>
-        document.querySelectorAll('.edit-btn').forEach(function(button) {
-            button.addEventListener('click', function() {
-                var targetId = this.getAttribute('data-target');
-                var form = document.getElementById(targetId);
-                if (!form) return;
-                form.style.display = form.style.display === 'none' || form.style.display === '' ? 'block' : 'none';
+        </div>
+    @endif
+</div>
+@endsection
+
+@push('scripts')
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('[data-edit-toggle]').forEach(function (button) {
+            button.addEventListener('click', function () {
+                const targetId = this.getAttribute('data-edit-toggle');
+                const panel = document.getElementById(targetId);
+                if (!panel) return;
+                const isOpen = panel.style.display === 'block';
+                panel.style.display = isOpen ? 'none' : 'block';
             });
         });
 
-        document.querySelectorAll('.cancel-edit').forEach(function(button) {
-            button.addEventListener('click', function() {
-                var targetId = this.getAttribute('data-target');
-                var form = document.getElementById(targetId);
-                if (!form) return;
-                form.style.display = 'none';
+        document.querySelectorAll('[data-close-panel]').forEach(function (button) {
+            button.addEventListener('click', function () {
+                const targetId = this.getAttribute('data-close-panel');
+                const panel = document.getElementById(targetId);
+                if (!panel) return;
+                panel.style.display = 'none';
             });
         });
 
         function setupCategorySelect(select) {
-            var recipeId = select.getAttribute('data-recipe-id');
-            var customGroup = document.getElementById('custom_category_group_' + recipeId);
+            const recipeId = select.getAttribute('id').replace('category_', '');
+            const customGroup = document.getElementById('custom_category_group_' + recipeId);
             if (!customGroup) return;
-            var customInput = customGroup.querySelector('input');
+            const customInput = customGroup.querySelector('input');
 
-            var toggleCustom = function(value) {
+            function toggleCustom(value) {
                 if (value === 'other') {
                     customGroup.style.display = 'block';
                     if (customInput) {
@@ -224,16 +232,15 @@
                         customInput.required = false;
                     }
                 }
-            };
+            }
 
             toggleCustom(select.value);
-
-            select.addEventListener('change', function() {
+            select.addEventListener('change', function () {
                 toggleCustom(this.value);
             });
         }
 
         document.querySelectorAll('.category-select').forEach(setupCategorySelect);
-    </script>
-</body>
-</html>
+    });
+</script>
+@endpush

--- a/resources/views/saved_recipes/index_local.blade.php
+++ b/resources/views/saved_recipes/index_local.blade.php
@@ -1,210 +1,257 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>My Local Recipes</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 40px; background: #f8fafc; }
-        .container { max-width: 800px; margin: auto; background: #fff; border-radius: 8px; box-shadow: 0 0 10px #ddd; padding: 24px;}
-        h1 { text-align: center; color: #333; }
-        .actions { display:flex; gap:8px; flex-wrap:wrap; margin-bottom: 16px; }
-        .btn { background:#38b6ff; color:#fff; border:none; padding:8px 14px; border-radius:4px; cursor:pointer; }
-        .btn.secondary { background:#64748b; }
-        .btn.danger { background:#ef4444; }
-        .card { background:#e3f5ff; border-radius:6px; padding:16px; margin-bottom:12px; }
-        .meta { color:#334155; font-size:12px; margin-top:6px; }
-        .empty { text-align:center; color:#6b7280; margin-top:20px; }
-        pre { white-space:pre-wrap; }
-    </style>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="csrf-token" content="{{ csrf_token() }}">
-    <link rel="preconnect" href="https://fonts.bunny.net">
-    <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
-</head>
-<body>
-    <div class="container">
-        <div style="text-align:right; margin-bottom:12px;">
-            <a href="/" style="color:#007bff;">Home</a>
-        </div>
+@extends('layouts.site')
 
-        <h1>My Local Recipes</h1>
-        <p style="text-align:center; color:#475569; margin-bottom:18px;">Local storage is limited to four recipes per browser.</p>
-		@guest
-			<div style="text-align:center; margin-bottom: 12px;">
-				<a href="/login" id="signinImportBtn" class="btn">Sign in to import all</a>
-			</div>
-		@endguest
-        <div class="actions">
-            <button class="btn" id="exportBtn">Export JSON</button>
-            <button class="btn secondary" id="importBtn">Import JSON</button>
-            <input type="file" id="importFile" accept="application/json" style="display:none;" />
-            <button class="btn danger" id="clearAllBtn">Clear All</button>
-        </div>
+@section('title', 'My Local Recipes | PrepToEat')
 
-        <div id="list"></div>
-        <div id="empty" class="empty" style="display:none;">No local recipes yet. Save some from the homepage.</div>
+@section('content')
+<div class="content-shell">
+    <div class="page-header">
+        <h1 class="page-title">My Local Recipes</h1>
+        <p class="page-subtitle">These recipes live in your browser. Export, import, or sync them to an account before clearing your cache.</p>
     </div>
 
-    <script>
-        (function() {
-            const KEY = 'guestRecipes';
-            const MAX_ITEMS = 4;
-            const listEl = document.getElementById('list');
-            const emptyEl = document.getElementById('empty');
-            const importFile = document.getElementById('importFile');
+    <div class="card" style="margin-bottom:2rem;">
+        <div style="display:flex; flex-wrap:wrap; gap:1rem; align-items:center; justify-content:space-between;">
+            <a class="muted-link" href="{{ url('/') }}">&larr; Back to recipe creator</a>
+            <div style="display:flex; gap:0.75rem; flex-wrap:wrap;">
+                <button class="btn btn-primary btn-small" id="exportBtn">Export JSON</button>
+                <button class="btn btn-secondary btn-small" id="importBtn">Import JSON</button>
+                <input type="file" id="importFile" accept="application/json" style="display:none;" />
+                <button class="btn btn-danger btn-small" id="clearAllBtn">Clear All</button>
+            </div>
+        </div>
+    </div>
 
-            function sanitizeRecipes(list) {
-                if (!Array.isArray(list)) return [];
+    @guest
+        <div class="card" style="margin-bottom:2rem; text-align:center;">
+            <p style="margin:0 0 1rem;">Create an account to back up your local recipes in the cloud.</p>
+            <a href="{{ route('login') }}" id="signinImportBtn" class="btn btn-primary btn-small" style="display:inline-flex;">Sign in to import all</a>
+        </div>
+    @endguest
 
-                const nowIso = new Date().toISOString();
-                const deduped = [];
-                const seen = new Set();
+    <div id="list" class="summary-grid"></div>
+    <div id="empty" class="card" style="display:none;">
+        <div class="empty-state">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75l7.5-3 7.5 3m-15 0l7.5 3 7.5-3m-15 0V17.25a2.25 2.25 0 001.344 2.07l6.375 2.85c.52.232 1.098.232 1.618 0l6.375-2.85A2.25 2.25 0 0019.5 17.25V6.75m-15 0L12 9.75" />
+            </svg>
+            <div>No local recipes yet. Save one from the homepage to get started.</div>
+        </div>
+    </div>
+</div>
+@endsection
 
-                for (const item of list) {
-                    if (!item || typeof item !== 'object') continue;
-                    const recipe = Object.assign({}, item);
-                    if (!recipe.id) {
-                        const fallbackId = 'gr_' + Date.now() + '_' + Math.random().toString(36).slice(2);
-                        recipe.id = (window.crypto && crypto.randomUUID) ? crypto.randomUUID() : fallbackId;
-                    }
-                    if (!recipe.savedAt) {
-                        recipe.savedAt = nowIso;
-                    }
-                    if (seen.has(recipe.id)) continue;
-                    seen.add(recipe.id);
-                    deduped.push(recipe);
+@push('scripts')
+<script>
+    (function() {
+        const KEY = 'guestRecipes';
+        const MAX_ITEMS = 4;
+        const listEl = document.getElementById('list');
+        const emptyEl = document.getElementById('empty');
+        const importFile = document.getElementById('importFile');
+
+        function sanitizeRecipes(list) {
+            if (!Array.isArray(list)) return [];
+
+            const nowIso = new Date().toISOString();
+            const deduped = [];
+            const seen = new Set();
+
+            for (const item of list) {
+                if (!item || typeof item !== 'object') continue;
+                const recipe = Object.assign({}, item);
+                if (!recipe.id) {
+                    const fallbackId = 'gr_' + Date.now() + '_' + Math.random().toString(36).slice(2);
+                    recipe.id = (window.crypto && crypto.randomUUID) ? crypto.randomUUID() : fallbackId;
                 }
-
-                deduped.sort(function(a, b) {
-                    return new Date(a.savedAt).getTime() - new Date(b.savedAt).getTime();
-                });
-
-                if (deduped.length > MAX_ITEMS) {
-                    deduped.splice(0, deduped.length - MAX_ITEMS);
+                if (!recipe.savedAt) {
+                    recipe.savedAt = nowIso;
                 }
-
-                return deduped;
+                if (seen.has(recipe.id)) continue;
+                seen.add(recipe.id);
+                deduped.push(recipe);
             }
 
-            function getAll() {
-                try {
-                    const parsed = JSON.parse(localStorage.getItem(KEY) || '[]');
-                    const sanitized = sanitizeRecipes(parsed);
-                    localStorage.setItem(KEY, JSON.stringify(sanitized));
-                    return sanitized;
-                } catch {
-                    return [];
-                }
+            deduped.sort(function(a, b) {
+                return new Date(a.savedAt).getTime() - new Date(b.savedAt).getTime();
+            });
+
+            if (deduped.length > MAX_ITEMS) {
+                deduped.splice(0, deduped.length - MAX_ITEMS);
             }
-            function setAll(arr, options = {}) {
-                const sanitized = sanitizeRecipes(arr);
+
+            return deduped;
+        }
+
+        function getAll() {
+            try {
+                const parsed = JSON.parse(localStorage.getItem(KEY) || '[]');
+                const sanitized = sanitizeRecipes(parsed);
                 localStorage.setItem(KEY, JSON.stringify(sanitized));
-                if (options.notifyLimit && sanitized.length < arr.length && arr.length > MAX_ITEMS) {
-                    alert('Only the most recent four recipes were kept due to the local storage limit.');
-                }
                 return sanitized;
+            } catch {
+                return [];
             }
-            function render() {
+        }
+        function setAll(arr, options = {}) {
+            const sanitized = sanitizeRecipes(arr);
+            localStorage.setItem(KEY, JSON.stringify(sanitized));
+            if (options.notifyLimit && sanitized.length < arr.length && arr.length > MAX_ITEMS) {
+                alert('Only the most recent four recipes were kept due to the local storage limit.');
+            }
+            return sanitized;
+        }
+        function render() {
+            const items = getAll();
+            listEl.innerHTML = '';
+            emptyEl.style.display = items.length ? 'none' : 'block';
+            items.forEach((r) => {
+                const card = document.createElement('article');
+                card.className = 'card';
+                card.style.display = 'flex';
+                card.style.flexDirection = 'column';
+                card.style.gap = '0.9rem';
+                card.innerHTML = `
+                    <header style="display:flex; justify-content:space-between; align-items:flex-start; gap:0.75rem;">
+                        <div>
+                            <h3 class="recipe-title" style="margin:0 0 0.35rem;">${escapeHtml(r.title || 'Untitled recipe')}</h3>
+                            <div class="recipe-meta" style="gap:0.45rem;">
+                                <span class="recipe-tag">${escapeHtml(r.category || 'Uncategorized')}</span>
+                                <span>Saved ${formatDate(r.savedAt)}</span>
+                            </div>
+                        </div>
+                        <div style="display:flex; gap:0.5rem;">
+                            <button class="btn btn-secondary btn-small" data-view="${r.id}">Details</button>
+                            <button class="btn btn-danger btn-small" data-delete="${r.id}">Delete</button>
+                        </div>
+                    </header>
+                    <section id="detail_${r.id}" style="display:none;">
+                        <div class="recipe-section">
+                            <div class="section-title">
+                                <span class="icon-circle">
+                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 4.5h-3a2.25 2.25 0 00-2.25 2.25v3m5.25-5.25h9m0 0h3a2.25 2.25 0 012.25 2.25v3m-5.25-5.25v15m0 0h-9m9 0h3a2.25 2.25 0 002.25-2.25v-3m-14.25 5.25h-3A2.25 2.25 0 012.25 18v-3m0-6v9" />
+                                    </svg>
+                                </span>
+                                Ingredients
+                            </div>
+                            <div class="note-box" style="background:rgba(56,182,255,0.06); border:none;">
+                                ${formatMultiline(r.ingredients)}
+                            </div>
+                        </div>
+                        <div class="recipe-section">
+                            <div class="section-title">
+                                <span class="icon-circle">
+                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L6.832 19.82a4.5 4.5 0 01-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 011.13-1.897L16.862 4.487zm0 0L19.5 7.125" />
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M18 13.5V21" />
+                                    </svg>
+                                </span>
+                                Instructions
+                            </div>
+                            <div class="note-box" style="background:rgba(56,182,255,0.06); border:none;">
+                                ${formatMultiline(r.instructions)}
+                            </div>
+                        </div>
+                        ${r.summary ? `
+                        <div class="recipe-section">
+                            <div class="section-title">
+                                <span class="icon-circle">
+                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 9.75L9 12l2.25 2.25m3-4.5L12 12l2.25 2.25M3.75 6h16.5M3.75 9.75h16.5M3.75 13.5h16.5M3.75 17.25h16.5" />
+                                    </svg>
+                                </span>
+                                Personal Notes
+                            </div>
+                            <div class="note-box" style="background:rgba(56,182,255,0.06); border:none;">
+                                ${formatMultiline(r.summary)}
+                            </div>
+                        </div>` : ''}
+                    </section>
+                `;
+                listEl.appendChild(card);
+            });
+        }
+
+        function formatDate(iso) {
+            if (!iso) return '—';
+            try { return new Date(iso).toLocaleString(); } catch { return iso; }
+        }
+        function escapeHtml(str) {
+            return String(str).replace(/[&<>\"]/g, function (s) {
+                return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[s]);
+            });
+        }
+        function formatMultiline(text) {
+            if (!text) return '';
+            return '<pre style="white-space:pre-wrap; margin:0; font-family:inherit;">' + escapeHtml(text) + '</pre>';
+        }
+
+        document.addEventListener('click', function(e) {
+            const viewId = e.target.getAttribute && e.target.getAttribute('data-view');
+            if (viewId) {
+                const panel = document.getElementById('detail_' + viewId);
+                if (panel) {
+                    panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
+                }
+            }
+            const delId = e.target.getAttribute && e.target.getAttribute('data-delete');
+            if (delId) {
                 const items = getAll();
-                listEl.innerHTML = '';
-                emptyEl.style.display = items.length ? 'none' : 'block';
-                items.forEach((r, idx) => {
-                    const card = document.createElement('div');
-                    card.className = 'card';
-                    card.innerHTML = `
-                        <div style="display:flex; justify-content:space-between; align-items:center; gap:8px;">
-                            <div>
-                                <div style="font-weight:600; font-size:18px;">${escapeHtml(r.title || 'Untitled')}</div>
-                                <div class="meta">Category: ${escapeHtml(r.category || '—')} · Saved: ${formatDate(r.savedAt)}</div>
-                            </div>
-                            <div style="display:flex; gap:8px;">
-                                <button class="btn secondary" data-view="${r.id}">View</button>
-                                <button class="btn danger" data-delete="${r.id}">Delete</button>
-                            </div>
-                        </div>
-                        <div id="detail_${r.id}" style="display:none; margin-top:10px; background:#fff; border-radius:6px; padding:12px;">
-                            <strong>Ingredients</strong>
-                            <pre>${escapeHtml(r.ingredients || '')}</pre>
-                            <strong>Instructions</strong>
-                            <pre>${escapeHtml(r.instructions || '')}</pre>
-                            ${r.summary ? `<strong>Summary</strong><pre>${escapeHtml(r.summary)}</pre>` : ''}
-                        </div>
-                    `;
-                    listEl.appendChild(card);
-                });
+                const next = items.filter(x => x.id !== delId);
+                setAll(next);
+                render();
             }
+        });
 
-            function formatDate(iso) {
-                if (!iso) return '—';
-                try { return new Date(iso).toLocaleString(); } catch { return iso; }
+        document.getElementById('clearAllBtn').addEventListener('click', function() {
+            if (confirm('Clear all local recipes?')) {
+                setAll([]);
+                render();
             }
-            function escapeHtml(str) {
-                return String(str).replace(/[&<>"]+/g, s => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[s]));
-            }
+        });
 
-            document.addEventListener('click', function(e) {
-                const viewId = e.target.getAttribute && e.target.getAttribute('data-view');
-                if (viewId) {
-                    const panel = document.getElementById('detail_' + viewId);
-                    if (panel) panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
-                }
-                const delId = e.target.getAttribute && e.target.getAttribute('data-delete');
-                if (delId) {
-                    const items = getAll();
-                    const next = items.filter(x => x.id !== delId);
-                    setAll(next);
+        document.getElementById('exportBtn').addEventListener('click', function() {
+            const data = getAll();
+            const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'my-local-recipes.json';
+            a.click();
+            URL.revokeObjectURL(url);
+        });
+
+        document.getElementById('importBtn').addEventListener('click', function() {
+            importFile.click();
+        });
+
+        const signInBtn = document.getElementById('signinImportBtn');
+        if (signInBtn) {
+            signInBtn.addEventListener('click', function() {
+                try { localStorage.removeItem('import_banner_dismissed'); } catch {}
+            });
+        }
+
+        importFile.addEventListener('change', function() {
+            const file = importFile.files[0];
+            if (!file) return;
+            const reader = new FileReader();
+            reader.onload = function() {
+                try {
+                    const current = getAll();
+                    const incoming = JSON.parse(reader.result || '[]');
+                    const merged = Array.isArray(incoming) ? current.concat(incoming) : current;
+                    setAll(merged, { notifyLimit: true });
                     render();
+                } catch (err) {
+                    alert('Invalid JSON file.');
                 }
-            });
+            };
+            reader.readAsText(file);
+            importFile.value = '';
+        });
 
-            document.getElementById('clearAllBtn').addEventListener('click', function() {
-                if (confirm('Clear all local recipes?')) {
-                    setAll([]);
-                    render();
-                }
-            });
-
-            document.getElementById('exportBtn').addEventListener('click', function() {
-                const data = getAll();
-                const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-                const url = URL.createObjectURL(blob);
-                const a = document.createElement('a');
-                a.href = url;
-                a.download = 'my-local-recipes.json';
-                a.click();
-                URL.revokeObjectURL(url);
-            });
-
-            document.getElementById('importBtn').addEventListener('click', function() {
-                importFile.click();
-            });
-				const signInBtn = document.getElementById('signinImportBtn');
-				if (signInBtn) {
-					signInBtn.addEventListener('click', function() {
-						try { localStorage.removeItem('import_banner_dismissed'); } catch {}
-					});
-				}
-            importFile.addEventListener('change', function() {
-                const file = importFile.files[0];
-                if (!file) return;
-                const reader = new FileReader();
-                reader.onload = function() {
-                    try {
-                        const current = getAll();
-                        const incoming = JSON.parse(reader.result || '[]');
-                        const merged = Array.isArray(incoming) ? current.concat(incoming) : current;
-                        setAll(merged, { notifyLimit: true });
-                        render();
-                    } catch (err) {
-                        alert('Invalid JSON file.');
-                    }
-                };
-                reader.readAsText(file);
-            });
-
-            render();
-        })();
-    </script>
-</body>
-</html>
-
-
+        render();
+    })();
+</script>
+@endpush


### PR DESCRIPTION
## Summary
- introduce a dedicated `site` layout with a polished header, button styles, and responsive foundations used by public pages
- redesign the home recipe experience with two-column layout, iconography for sections, and unified save interactions
- refresh saved recipe listings (cloud and local) with card grids, icons, and improved edit/import tooling across devices

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf754342c0832aaa80d35d2e76dc3f